### PR TITLE
Forward compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,12 @@ desc = 'A Python logging handler for Fluentd event collector'
 
 setup(
   name='fluent-logger',
-  version='0.9.3.affirm0',
+  version='0.9.3+affirm1',
   description=desc,
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},
   packages=['fluent'],
-  install_requires=['msgpack'],
+  install_requires=['msgpack<1.0.0'],
   author='Kazuki Ohta',
   author_email='kazuki.ohta@gmail.com',
   url='https://github.com/fluent/fluent-logger-python',
@@ -37,6 +37,6 @@ setup(
     'Topic :: System :: Logging',
     'Intended Audience :: Developers',
   ],
-  python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3,<3.8",
+  python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3",
   test_suite='tests'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 1.7.2
-envlist = py27, py32, py33, py34, py35
+envlist = py27, py36, py37, py38, py39
 skip_missing_interpreters = True
 
 [testenv]
 deps = nose
-    coverage>=3.7,<3.8
+    coverage~=4.5.4
 commands = python setup.py nosetests


### PR DESCRIPTION
PEP 440-compatible version
Remove python version compat upper bound, in line with upstream
Pin msgpack to avoid API break, in line with upstream